### PR TITLE
Add httpcore_11 case

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ snakeviz==2.*
 tqdm==4.*
 dataclasses==0.*; python_version<'3.7'
 Jinja2==2.*
+irl==0.2

--- a/src/pyhttpbenchmark/cases/httpcore_11.py
+++ b/src/pyhttpbenchmark/cases/httpcore_11.py
@@ -1,0 +1,70 @@
+import ssl
+from .. import model
+from ..case import async_record_measure
+
+import asyncio
+import httpcore
+import irl
+
+"""
+httpcore HTTP/1.1
+"""
+
+
+async def get(url, transport):
+    urlobj = irl.URL.parse(url)
+
+    assert urlobj.scheme in ("http", "https")
+    assert urlobj.host is not None
+    scheme = urlobj.scheme.encode("utf-8")
+    host = urlobj.host.encode("utf-8")
+    port = urlobj.port
+    full_path = urlobj.target()
+
+    http_version, status_code, status_phrase, headers, stream = await transport.request(
+        method=b"GET",
+        url=(scheme, host, port, full_path),
+        headers=[(b"host", urlobj.host_header())],
+    )
+
+    try:
+        content = b"".join([chunk async for chunk in stream])
+    finally:
+        await stream.aclose()
+
+    return content
+
+
+async def step_delay(step, transport):
+    await asyncio.sleep(step.time)
+    return []
+
+
+async def step_requests(step, transport):
+    return [asyncio.create_task(get(url, transport)) for url in step.urls]
+
+
+async def step_request(step, transport):
+    await get(step.url, transport)
+    return []
+
+
+handlers: dict = {
+    model.StepDelay: step_delay,
+    model.StepRequests: step_requests,
+    model.StepRequest: step_request,
+}
+
+
+async def main(scenario: model.Scenario, sslconfig: model.SslConfig) -> None:
+    ssl_context = (
+        ssl.create_default_context(cafile=str(sslconfig.local_ca_file))
+        if scenario.local_ca
+        else None
+    )
+    async with httpcore.AsyncConnectionPool(ssl_context=ssl_context) as transport:
+        async with async_record_measure():
+            tasks = []
+            for step in scenario.steps:
+                tasks += await handlers[step.__class__](step, transport)
+            await asyncio.gather(*tasks)


### PR DESCRIPTION
Add a case for [HTTPCore](https://github.com/encode/httpcore) + HTTP/1.1.

I was super interested in seeing how HTTPCore performs vs aiohttp and HTTPX ("HTTPCore + client smarts").

Here are the results I've seen on the "small response" and "large response" cases:

```
## Scenario 1_100seq_2kb: 100 sequential requests, 2KB response, 0 delay
|                                  | Runtime |         |         | Cputime |         |         |
|----------------------------------|---------|---------|---------|---------|---------|---------|
|                                  |  median |    mean |   stdev |  median |    mean |   stdev |
| aiohttp                          |    0.25 |    0.25 |    0.04 |    0.12 |    0.12 |    0.01 |
| httpx_11                         |    0.30 |    0.32 |    0.06 |    0.21 |    0.21 |    0.02 |
| httpcore_11                      |    0.20 |    0.22 |    0.06 |    0.10 |    0.10 |    0.02 |

## Scenario 1_100seq_256kb: 100 sequential requests, 256KB response, 0 delay
|                                  | Runtime |         |         | Cputime |         |         |
|----------------------------------|---------|---------|---------|---------|---------|---------|
|                                  |  median |    mean |   stdev |  median |    mean |   stdev |
| aiohttp                          |    0.51 |    0.55 |    0.14 |    0.32 |    0.33 |    0.02 |
| httpx_11                         |    1.52 |    1.52 |    0.19 |    1.23 |    1.22 |    0.06 |
| httpcore_11                      |    0.90 |    1.04 |    0.37 |    0.69 |    0.71 |    0.12 |
```

Confirms what I thought — HTTPX plays a big role in the slowness on big responses… There's probably something to optimize, perhaps related to content decoding (chardet? https://github.com/encode/httpx/issues/1018), or something else…

Anyway, submitting if you'd like to get this in the main branch, but I have the code in my fork too so as you'd like. :-)