### PR TITLE
Add support for macOS

### DIFF
--- a/src/pyhttpbenchmark/server/server.py
+++ b/src/pyhttpbenchmark/server/server.py
@@ -15,9 +15,10 @@ from . import app, generate_certificates
 from .. import model, scenarios
 
 
+PLATFORM = "mac" if sys.platform == "darwin" else "linux"
 CADDY_VERSION = "2.1.1"
 CADDY_URL = (
-    f"https://github.com/caddyserver/caddy/releases/download/v{CADDY_VERSION}/caddy_{CADDY_VERSION}_linux_amd64.tar.gz"
+    f"https://github.com/caddyserver/caddy/releases/download/v{CADDY_VERSION}/caddy_{CADDY_VERSION}_{PLATFORM}_amd64.tar.gz"
 )
 CADDYFILE_TEMPLATE_PATH = pathlib.Path(__file__).parent.absolute() / "Caddyfile.template"
 


### PR DESCRIPTION
Downloads the Caddy tarball for macOS when running on macOS, allowing to run `pyhttpbenchmark` on Mac machines.

Used this for the test runs on #1 - again feel free to ignore if you'd like to keep your repo focused on your usage (I have this in my fork anyway). 😄 